### PR TITLE
Handle empty CFString conversion

### DIFF
--- a/signer_darwin.go
+++ b/signer_darwin.go
@@ -98,7 +98,16 @@ func (k *CustomSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) 
 // stringToCFString converts Go string to CFStringRef
 func stringToCFString(s string) C.CFStringRef {
 	bytes := []byte(s)
-	ptr := (*C.UInt8)(&bytes[0])
+	if len(bytes) == 0 {
+		return C.CFStringCreateWithBytes(
+			C.kCFAllocatorDefault,
+			nil,
+			0,
+			C.kCFStringEncodingUTF8,
+			C.false,
+		)
+	}
+	ptr := (*C.UInt8)(unsafe.Pointer(&bytes[0]))
 	return C.CFStringCreateWithBytes(C.kCFAllocatorDefault, ptr, C.CFIndex(len(bytes)), C.kCFStringEncodingUTF8, C.false)
 }
 

--- a/signer_darwin_test.go
+++ b/signer_darwin_test.go
@@ -1,0 +1,25 @@
+//go:build darwin && cgo
+
+package mTLS
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+*/
+import "C"
+import "testing"
+
+func TestStringToCFStringEmpty(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("stringToCFString panicked: %v", r)
+		}
+	}()
+
+	cfStr := stringToCFString("")
+	if got := CFStringToString(cfStr); got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+	C.CFRelease(C.CFTypeRef(cfStr))
+}


### PR DESCRIPTION
## Summary
- avoid panics in `stringToCFString` by checking for empty strings and using a nil pointer
- add test to ensure empty certificate names don't cause panic

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb5470b75c832e94b12647028f2acc