### PR TITLE
Release CFError resources on signing errors

### DIFF
--- a/signer_darwin.go
+++ b/signer_darwin.go
@@ -86,6 +86,8 @@ func (k *CustomSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) 
 	)
 	if cfErrorRef != 0 {
 		cdescription := C.CFErrorCopyDescription(cfErrorRef)
+		defer C.CFRelease(C.CFTypeRef(cdescription))
+		C.CFRelease(C.CFTypeRef(cfErrorRef))
 		fmt.Printf("DEBUG: %v", CFStringToString(cdescription))
 		return nil, fmt.Errorf("failed to sign data: %v", CFStringToString(cdescription))
 	}

--- a/signer_darwin_test.go
+++ b/signer_darwin_test.go
@@ -8,7 +8,12 @@ package mTLS
 #include <Security/Security.h>
 */
 import "C"
-import "testing"
+import (
+	"crypto"
+	"crypto/x509"
+	"runtime"
+	"testing"
+)
 
 func TestStringToCFStringEmpty(t *testing.T) {
 	defer func() {
@@ -22,4 +27,26 @@ func TestStringToCFStringEmpty(t *testing.T) {
 		t.Fatalf("expected empty string, got %q", got)
 	}
 	C.CFRelease(C.CFTypeRef(cfStr))
+}
+
+func TestSignErrorMemory(t *testing.T) {
+	signer := &CustomSigner{x509Cert: &x509.Certificate{}, privateKey: 0}
+	digest := make([]byte, 32)
+
+	var m1, m2 runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&m1)
+
+	for i := 0; i < 1000; i++ {
+		if _, err := signer.Sign(nil, digest, crypto.SHA256); err == nil {
+			t.Fatalf("expected error")
+		}
+	}
+
+	runtime.GC()
+	runtime.ReadMemStats(&m2)
+
+	if delta := m2.Alloc - m1.Alloc; delta > 1<<20 {
+		t.Fatalf("memory grew by %d bytes", delta)
+	}
 }


### PR DESCRIPTION
## Summary
- release description string with `CFRelease` after `CFErrorCopyDescription`
- free `CFErrorRef` before returning on signing failures
- add regression test to ensure repeated signing errors don't leak memory

## Testing
- `go test ./...`
- `GOOS=darwin CGO_ENABLED=1 go test ./...` *(fails: use of cgo in test signer_darwin_test.go not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68bb56f7e77c832eb0c8c5abefad75d4