### PR TITLE
Cache parsed PKCS#12 certificate in EmbeddedSigner

### DIFF
--- a/certificate.go
+++ b/certificate.go
@@ -18,5 +18,8 @@ func (s *EmbeddedSigner) GetClientCertificate(info *tls.CertificateRequestInfo) 
 			PrivateKey:  key,
 		}
 	})
-	return s.certificate, s.err
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.certificate, nil
 }

--- a/signer.go
+++ b/signer.go
@@ -25,7 +25,10 @@ type EmbeddedSigner struct {
 	PKCS12   []byte
 	Password string
 
+	// once ensures the certificate is loaded and cached only once.
 	once        sync.Once
+	// certificate caches the loaded TLS certificate for repeated use.
 	certificate *tls.Certificate
+	// err stores any error encountered during certificate loading.
 	err         error
 }

--- a/signer.go
+++ b/signer.go
@@ -24,4 +24,8 @@ type SystemSigner struct {
 type EmbeddedSigner struct {
 	PKCS12   []byte
 	Password string
+
+	once        sync.Once
+	certificate *tls.Certificate
+	err         error
 }


### PR DESCRIPTION
## Summary
- cache parsed PKCS#12 certificate in EmbeddedSigner using sync.Once
- reuse decoded certificate on subsequent handshakes to cut overhead

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68bb61620570832ea8d24d26aeb82ceb